### PR TITLE
dev: 按需创建测试 S3 桶

### DIFF
--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -24,14 +24,14 @@ output "lambda_function_arn" {
 #   value       = module.test_bucket.bucket_arn
 # }
 
-# CI/CD 测试 S3 桶输出 - 临时注释用于测试 GitOps 工作流
-# output "test_cicd_bucket_name" {
-#   description = "CI/CD 测试 S3 桶名称"
-#   value       = module.test_cicd_bucket.bucket_id
-# }
-#
-# output "test_cicd_bucket_arn" {
-#   description = "CI/CD 测试 S3 桶 ARN"
-#   value       = module.test_cicd_bucket.bucket_arn
-# }
+// CI/CD 测试 S3 桶输出（受 enable_test_cicd_bucket 控制）
+output "test_cicd_bucket_name" {
+  description = "CI/CD 测试 S3 桶名称"
+  value       = try(module.test_cicd_bucket[0].bucket_id, null)
+}
+
+output "test_cicd_bucket_arn" {
+  description = "CI/CD 测试 S3 桶 ARN"
+  value       = try(module.test_cicd_bucket[0].bucket_arn, null)
+}
 

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -46,3 +46,9 @@ variable "lambda_timeout" {
   default     = 20
 }
 
+variable "enable_test_cicd_bucket" {
+  description = "是否启用 dev 环境的测试 S3 桶"
+  type        = bool
+  default     = false
+}
+


### PR DESCRIPTION
- 新增 enable_test_cicd_bucket 变量
- 仅在启用时创建 random_id 与 test_cicd_bucket
- 输出采用 try 以避免未创建时报错